### PR TITLE
Add CCDC to OpenBabel (and reverse) convertors

### DIFF
--- a/ccdc_convertor.py
+++ b/ccdc_convertor.py
@@ -1,11 +1,13 @@
 import sys
 resetopenflags = sys.getdlopenflags()
-from ccdc.molecule import Molecule as CCDCMolecule
+from ccdc.molecule import Molecule as CCDCMolecule, Atom as CCDCAtom, Bond as CCDCBond
 sys.setdlopenflags(resetopenflags)
 
 from openmm import Vec3
 from openmm.app.topology import Topology as OpenMMTopology
 from openmm.app.element import Element as OpenMMElement
+
+from openbabel import OBMol as OpenBabelMolecule
 
 from typing import Any
 
@@ -54,3 +56,77 @@ def openmm_topology_and_positions_from_ccdc_molecule(ccdc_mol: CCDCMolecule) -> 
         )
 
     return topology, positions
+
+
+def openbabel_molecule_from_ccdc_molecule(ccdc_mol: CCDCMolecule) -> OpenBabelMolecule:
+    """Converts a molecule from CSD Python API to OpenBabel types.
+
+    :param ccdc_mol: the CSD Python API Molecule to convert
+    :return: an openbabel.OBMol object
+    """
+    ob_mol = OpenBabelMolecule()
+    ob_mol.SetAromaticPerceived()   # tell openbabel we are defining aromaticity ourselves
+
+    ccdc_to_ob_atom_map = dict()
+
+    for ccdc_atom in ccdc_mol.atoms:
+        ob_atom = ob_mol.NewAtom()
+        ob_atom.SetTitle(ccdc_atom.label)
+        ob_atom.SetAtomicNum(ccdc_atom.atomic_number)
+        ob_atom.SetVector(*ccdc_atom.coordinates)
+        ccdc_to_ob_atom_map[ccdc_atom] = ob_atom
+
+    for ccdc_bond in ccdc_mol.bonds:
+        ob_bond = ob_mol.NewBond()
+        begin_atom = ccdc_to_ob_atom_map[ccdc_bond.atoms[0]]
+        end_atom = ccdc_to_ob_atom_map[ccdc_bond.atoms[1]]
+        ob_bond.SetBegin(begin_atom)
+        ob_bond.SetEnd(end_atom)
+        begin_atom.AddBond(ob_bond)
+        end_atom.AddBond(ob_bond)
+
+        if ccdc_bond.bond_type == 'Single':
+            ob_bond.SetBondOrder(1)
+        elif ccdc_bond.bond_type == 'Double':
+            ob_bond.SetBondOrder(2)
+        elif ccdc_bond.bond_type == 'Triple':
+            ob_bond.SetBondOrder(3)
+        elif ccdc_bond.bond_type == 'Aromatic':
+            ob_bond.SetBondOrder(5)
+            ob_bond.SetAromatic()
+
+    return ob_mol
+
+
+def ccdc_molecule_from_openbabel_molecule(ob_mol: OpenBabelMolecule) -> CCDCMolecule:
+    """Converts a molecule from OpenBabel to CSD Python API types.
+
+    :param ccdc_mol: the openbabel.OBMol object to convert
+    :return: a CSD Python API Molecule
+    """
+    ccdc_mol = CCDCMolecule()
+
+    for i in range(ob_mol.NumAtoms()):
+        ob_atom  = ob_mol.GetAtom(i + 1)
+        ccdc_atom = CCDCAtom(
+            atomic_number=ob_atom.GetAtomicNum(),
+            coordinates=(ob_atom.x(), ob_atom.y(), ob_atom.z())
+        )
+        ccdc_mol.add_atom(ccdc_atom)
+
+    for i in range(ob_mol.NumBonds()):
+        ob_bond  = ob_mol.GetBond(i)
+
+        ccdc_bond_type = 'Unknown'
+        if ob_bond.IsAromatic():
+            ccdc_bond_type = 'Aromatic'
+        elif ob_bond.GetBondOrder() == 1:
+            ccdc_bond_type = 'Single'
+        elif ob_bond.GetBondOrder() == 2:
+            ccdc_bond_type = 'Double'
+        elif ob_bond.GetBondOrder() == 3:
+            ccdc_bond_type = 'Triple'
+
+        ccdc_mol.add_bond(bond_type=CCDCBond.BondType(ccdc_bond_type), atom1=ccdc_mol.atoms[ob_bond.GetBeginAtomIdx() - 1], atom2=ccdc_mol.atoms[ob_bond.GetEndAtomIdx() - 1])
+    
+    return ccdc_mol

--- a/tests/test_ccdc_convertor.py
+++ b/tests/test_ccdc_convertor.py
@@ -4,10 +4,17 @@ import unittest
 import os.path
 
 import ccdc_convertor
+import openbabel
 
 from ccdc.io import EntryReader
 from ccdc.protein import Protein as CCDCProtein
 from openmm.app.element import Element as OpenMMElement
+
+
+def advance_iterator(iterator, n_steps):
+    for _ in range(n_steps):
+        item = next(iterator)
+    return item
 
 
 class TestCCDCConvertor(unittest.TestCase):
@@ -57,3 +64,59 @@ class TestCCDCConvertor(unittest.TestCase):
         self.assertTrue(atoms[5000] in residues[310].atoms())  # CE in A:LYS311
         self.assertTrue(atoms[10000] in residues[624].atoms()) # HG23 in B:ILE74
         self.assertTrue(atoms[14999] in residues[928].atoms()) # OH in B:378
+
+    def test_openbabel_from_ccdc_molecule(self):
+        reader = EntryReader('csd')
+        entry = reader.entry('ACSALA')
+        ccdc_molecule = entry.molecule
+
+        ob_mol = ccdc_convertor.openbabel_molecule_from_ccdc_molecule(ccdc_molecule)
+
+        self.assertEqual(21, ob_mol.NumAtoms())
+        self.assertEqual(21, ob_mol.NumBonds())
+
+        atom_iterator = openbabel.OBMolAtomIter(ob_mol)
+        atom = advance_iterator(atom_iterator, 1)
+        self.assertEqual(atom.GetAtomicNum(), 6)
+        self.assertAlmostEqual(1.678, atom.GetX(), places=3)
+        self.assertAlmostEqual(2.879, atom.GetY(), places=3)
+        self.assertAlmostEqual(0.764, atom.GetZ(), places=3)
+        self.assertEqual(3, atom.GetTotalDegree())
+
+        atom = advance_iterator(atom_iterator, 17)
+        self.assertEqual(atom.GetAtomicNum(), 8)
+        self.assertAlmostEqual(0.015, atom.GetX(), places=3)
+        self.assertAlmostEqual(1.237, atom.GetY(), places=3)
+        self.assertAlmostEqual(1.095, atom.GetZ(), places=3)
+        self.assertEqual(1, atom.GetTotalDegree())
+
+        bond_iterator = openbabel.OBMolBondIter(ob_mol)
+        bond = advance_iterator(bond_iterator, 1)       # C1-C2
+        self.assertEqual(1, bond.GetBeginAtomIdx())
+        self.assertEqual(2, bond.GetEndAtomIdx())
+        self.assertTrue(bond.IsAromatic())
+
+        bond = advance_iterator(bond_iterator, 16)      # O1-C7
+        self.assertEqual(18, bond.GetBeginAtomIdx())
+        self.assertEqual(7, bond.GetEndAtomIdx())
+        self.assertFalse(bond.IsAromatic())
+        self.assertEqual(2, bond.GetBondOrder())
+
+    def test_ccdc_to_openbabel_round_trip(self):
+        reader = EntryReader('csd')
+        entry = reader.entry('ACSALA')
+        ccdc_molecule = entry.molecule
+
+        ob_mol = ccdc_convertor.openbabel_molecule_from_ccdc_molecule(ccdc_molecule)
+        ccdc_molecule2 = ccdc_convertor.ccdc_molecule_from_openbabel_molecule(ob_mol)
+
+        self.assertEqual(len(ccdc_molecule.atoms), len(ccdc_molecule2.atoms))
+        for atom1, atom2 in zip(ccdc_molecule.atoms, ccdc_molecule2.atoms):
+            self.assertEqual(atom1.atomic_number, atom2.atomic_number)
+            self.assertEqual(atom1.coordinates, atom2.coordinates)
+
+        self.assertEqual(len(ccdc_molecule.bonds), len(ccdc_molecule2.bonds))
+        for i, (bond1, bond2) in enumerate(zip(ccdc_molecule.bonds, ccdc_molecule2.bonds)):
+            self.assertEqual(bond1.atoms[0].index, bond2.atoms[0].index)
+            self.assertEqual(bond1.atoms[1].index, bond2.atoms[1].index)
+            self.assertEqual(bond1.bond_type, bond2.bond_type, msg=f'{i}: {bond1.bond_type} != {bond2.bond_type}')


### PR DESCRIPTION
Added:
- `openbabel_molecule_from_ccdc_molecule` to convert from a CCDC `Molecule` to an `OBMol`
- `ccdc_molecule_from_openbabel_molecule` for the reverse